### PR TITLE
Correct most of Rubocop offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,21 +5,23 @@ gem 'responders'
 gem 'uglifier'
 gem 'jquery-rails'
 gem 'less-rails'
-gem 'therubyracer', :platforms => :ruby
+gem 'therubyracer', platforms: :ruby
 gem 'bootstrap-on-rails'
 gem 'turbolinks'
 gem 'pg'
 gem 'puma'
 gem 'slim-rails'
 gem 'git'
-gem 'appconfig', :require => 'app_config'
+gem 'appconfig', require: 'app_config'
 gem 'sidekiq'
 gem 'sidetiq' # Recurring jobs
-gem 'sinatra', '>= 1.3.0', :require => nil
+gem 'sinatra', '>= 1.3.0', require: nil
 gem 'newrelic_rpm'
 gem 'nokogiri'
-gem 'open_uri_redirections' # open-uri library patched to follow http to https redirects
-gem 'array_is_uniq', :require => 'array' # Implemented the missing unqi? method on Ruby Arrays
+# open-uri library patched to follow http to https redirects
+gem 'open_uri_redirections'
+# Implemented the missing uniq? method on Ruby Arrays
+gem 'array_is_uniq', require: 'array'
 gem 'pluralize_no_count_if_one'
 gem 'quiet_assets'
 
@@ -29,23 +31,23 @@ end
 
 group :development do
   gem 'better_errors'
-  gem 'binding_of_caller', :platforms=>[:mri_19, :mri_20, :rbx]
-  gem 'hub', :require => nil
+  gem 'binding_of_caller', platforms: [:mri_19, :mri_20, :rbx]
+  gem 'hub', require: nil
   gem 'rails_layout'
   gem 'yard'
   gem 'rails_best_practices'
-  gem 'rubocop'
+  gem 'rubocop', require: false
 end
 
 group :test, :cucumber do
   gem 'capybara'
-  gem 'cucumber-rails', :require => false
+  gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'launchy'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
-  gem 'cucumber-timecop', '0.0.3', :require => false
+  gem 'cucumber-timecop', '0.0.3', require: false
   gem 'rake'
   gem 'webmock'
   gem 'coveralls', require: false

--- a/app/controllers/formulas_controller.rb
+++ b/app/controllers/formulas_controller.rb
@@ -27,10 +27,10 @@ class FormulasController < ApplicationController
 
   def search
     @formulas = Homebrew::Formula.active_or_external.where(
-                  'filename iLIKE ? OR name iLIKE ?',
-                  "%#{params[:search][:term]}%",
-                  "%#{params[:search][:term]}%"
-                ).order(:name)
+      'filename iLIKE ? OR name iLIKE ?',
+      "%#{params[:search][:term]}%",
+      "%#{params[:search][:term]}%"
+    ).order(:name)
   end
 
   private
@@ -40,10 +40,10 @@ class FormulasController < ApplicationController
                                        params[:id].downcase).first!
   rescue ActiveRecord::RecordNotFound
     respond_to do |format|
-      format.html {
+      format.html do
         flash[:error] = 'This formula doesn\'t exists'
         redirect_to root_url
-      }
+      end
       format.json { respond_with({}, status: :not_found) }
     end
   end
@@ -54,12 +54,10 @@ class FormulasController < ApplicationController
 
   def calculate_percentage
     with_a_description_count = Homebrew::Formula.internals
-                                                .with_a_description.count
+                               .with_a_description.count
     @coverage = 0
-
-    unless with_a_description_count.zero? || @formulas.size.zero?
-      @coverage = (with_a_description_count * 100) / @formulas.size
-    end
+    @coverage = (with_a_description_count * 100) / @formulas.size unless
+      with_a_description_count.zero? || @formulas.size.zero?
   end
 
   def new_since_a_week
@@ -78,13 +76,13 @@ class FormulasController < ApplicationController
   def respond_with_format
     respond_to do |format|
       format.html
-      format.json {
+      format.json do
         if action_name == 'show'
           respond_with(@formula, status: :ok)
         else
           respond_with([], status: 415)
         end
-      }
+      end
     end
   end
 end

--- a/app/models/homebrew/formula.rb
+++ b/app/models/homebrew/formula.rb
@@ -118,16 +118,14 @@ module Homebrew
       description = Homebrew::Formula::Description.new(self)
       description.lookup_from(html)
 
-      # In the case a description has been found
-      if description.found?
-        unless update_attributes(
-          description: description.text,
-          description_automatic: true
-        )
-          Rails.logger.warn 'Unable to update description with text ' \
-                            "#{description.text}"
-        end
-      end
+      return unless description.found?
+      return if update_attributes(
+        description: description.text,
+        description_automatic: true
+      )
+
+      Rails.logger.warn 'Unable to update description with text ' \
+                        "#{description.text}"
     end
 
     def reference
@@ -142,7 +140,7 @@ module Homebrew
       created_at.to_date == Time.now.utc.to_date
     end
 
-    def as_json(options = {})
+    def as_json(_options = {}) # rubocop:disable Metrics/AbcSize
       {
         formula: name.downcase,
         description: description.to_s,
@@ -152,7 +150,7 @@ module Homebrew
         dependencies: dependencies.map(&:name).sort,
         dependents: formula_dependents.map(&:formula).map(&:name).sort
       }
-    end
+    end # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/app/models/homebrew/tools.rb
+++ b/app/models/homebrew/tools.rb
@@ -58,7 +58,7 @@ module Homebrew
 
       conflicts.gsub!(/('|")/, '')
 
-      conflicts, _ = extract_conflict_reason_if_possible!(conflicts)
+      conflicts, = extract_conflict_reason_if_possible!(conflicts)
 
       conflicting_formulas = conflicts.strip.split(',').map(&:strip)
       conflicting_formulas.map do |name|

--- a/app/models/homepage.rb
+++ b/app/models/homepage.rb
@@ -29,7 +29,6 @@ class Homepage
 
   private
 
-
   #
   # Fetch the HTML content from a given URL
   # @param url [String] URL from where to fetch the content

--- a/app/models/software_description_fetchers/strategies/default.rb
+++ b/app/models/software_description_fetchers/strategies/default.rb
@@ -11,7 +11,8 @@ module SoftwareDescriptionFetchers
           fail ArgumentError, 'You must provide a name and a filename'
         end
 
-        @software_name, @software_filename = options[:name], options[:filename]
+        @software_name = options[:name]
+        @software_filename = options[:filename]
         @html = nokogiri_html
       end
 
@@ -29,10 +30,10 @@ module SoftwareDescriptionFetchers
       end
 
       def regex
-        /(^.*(?:#{@software_name}|#{@software_filename})
+        %r{(^.*(?:#{@software_name}|#{@software_filename})
           (?:\)|\s\u2122|\s[\d\.]+|\scodec)?\s(?:is\s
           (?:an?|the)|(?:project\s)?provides)[\s\w\'\(\)\,\-\+\/\.\:]+\.(?:\s|$)
-        )/ix
+        )}ix
       end
 
       def look_html_body

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -50,7 +50,6 @@ set :puma_init_active_record, false
 set :puma_preload_app, true
 
 namespace :deploy do
-
   desc 'Restart application'
   task :restart do
     on roles(:app), in: :sequence, wait: 5 do
@@ -69,5 +68,4 @@ namespace :deploy do
       # end
     end
   end
-
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ BrewformulasOrg::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true  # Send email in development mode.
+  config.assets.debug = true # Send email in development mode.
   config.action_mailer.perform_deliveries = true
 
   # Precompiled assets always have a digest now

--- a/config/initializers/00_tutum.rb
+++ b/config/initializers/00_tutum.rb
@@ -1,7 +1,5 @@
 # When running on Tutum.co platform, redirect the logs to the standard output
 # so that they are accessible from the Tutum.co dashboard
-if ENV.key?('TUTUM')
-  Rails.logger = Logger.new(STDOUT)
-end
+Rails.logger = Logger.new(STDOUT) if ENV.key?('TUTUM')
 
-Rails.logger.info "Tutum initialization done."
+Rails.logger.info 'Tutum initialization done.'

--- a/lib/tasks/brewformulas.org.rake
+++ b/lib/tasks/brewformulas.org.rake
@@ -1,21 +1,22 @@
 namespace :brewformulas do
-  desc "Dump Formula homepage into a fixture file"
-  task :dump_homepage, [:formula_name] => [:environment] do |t, args|
+  desc 'Dump Formula homepage into a fixture file'
+  task :dump_homepage, [:formula_name] => [:environment] do |_t, args|
     formula = Homebrew::Formula.find_by!(name: args[:formula_name])
 
-    raise "Formula #{formula.name} has no homepage!" unless formula.homepage
+    fail "Formula #{formula.name} has no homepage!" unless formula.homepage
 
-    fixture_path = Rails.root.join("features", "fixtures", "webmock", formula.name.downcase)
-    raise "A fixture file already exists for Formula #{formula.name}!" if File.exists?(fixture_path)
+    fixture_path = Rails.root.join('features', 'fixtures',
+                                   'webmock', formula.name.downcase)
+    fail "A fixture file already exists for Formula #{formula.name}!" if File.exist?(fixture_path)
 
-    puts "Getting homepage..."
+    puts 'Getting homepage...'
     homepage = Homepage.new(formula.homepage)
 
-    puts "Saving homepage..."
-    FileUtils.mkdir_p(fixture_path) unless File.exists?(fixture_path)
-    File.open(File.join(fixture_path, "index.html"), "w") {|file|
+    puts 'Saving homepage...'
+    FileUtils.mkdir_p(fixture_path) unless File.exist?(fixture_path)
+    File.open(File.join(fixture_path, 'index.html'), 'w') do|file|
       file.write(homepage.fetch)
-    }
+    end
     puts "#{formula.name}'s homepage successfully dumped in #{fixture_path}."
   end
 end

--- a/lib/tasks/coveralls.rake
+++ b/lib/tasks/coveralls.rake
@@ -1,8 +1,9 @@
 begin
   require 'coveralls/rake/task'
   Coveralls::RakeTask.new
-  task :default => [:spec, :cucumber, 'coveralls:push']
+  task default: [:spec, :cucumber, 'coveralls:push']
 rescue LoadError
+  puts 'not loading coveralls'
   # When loading this file out of the test profile
   # coveralls is not installed
 end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -4,62 +4,61 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gems:* tasks
 
-unless ARGV.any? {|a| a =~ /^gems/} # Don't load anything when running the gems:* tasks
+  vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
+  $LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
 
-vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
-$LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
+  begin
+    require 'cucumber/rake/task'
 
-begin
-  require 'cucumber/rake/task'
+    namespace :cucumber do
+      Cucumber::Rake::Task.new({ ok: 'test:prepare' }, 'Run features that should pass') do |t|
+        t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
+        t.fork = true # You may get faster startup if you set this to false
+        t.profile = 'default'
+      end
 
-  namespace :cucumber do
-    Cucumber::Rake::Task.new({:ok => 'test:prepare'}, 'Run features that should pass') do |t|
-      t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'default'
+      Cucumber::Rake::Task.new({ wip: 'test:prepare' }, 'Run features that are being worked on') do |t|
+        t.binary = vendored_cucumber_bin
+        t.fork = true # You may get faster startup if you set this to false
+        t.profile = 'wip'
+      end
+
+      Cucumber::Rake::Task.new({ rerun: 'test:prepare' }, 'Record failing features and run only them if any exist') do |t|
+        t.binary = vendored_cucumber_bin
+        t.fork = true # You may get faster startup if you set this to false
+        t.profile = 'rerun'
+      end
+
+      desc 'Run all features'
+      task all: [:ok, :wip]
+
+      task :statsetup do
+        require 'rails/code_statistics'
+        ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
+        ::CodeStatistics::TEST_TYPES << 'Cucumber features' if File.exist?('features')
+      end
+    end
+    desc 'Alias for cucumber:ok'
+    task cucumber: 'cucumber:ok'
+
+    task default: :cucumber
+
+    task features: :cucumber do
+      STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
     end
 
-    Cucumber::Rake::Task.new({:wip => 'test:prepare'}, 'Run features that are being worked on') do |t|
-      t.binary = vendored_cucumber_bin
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'wip'
+    # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.
+    task 'test:prepare' do
     end
 
-    Cucumber::Rake::Task.new({:rerun => 'test:prepare'}, 'Record failing features and run only them if any exist') do |t|
-      t.binary = vendored_cucumber_bin
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'rerun'
-    end
-
-    desc 'Run all features'
-    task :all => [:ok, :wip]
-
-    task :statsetup do
-      require 'rails/code_statistics'
-      ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
-      ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
+    task stats: 'cucumber:statsetup'
+  rescue LoadError
+    desc 'cucumber rake task not available (cucumber not installed)'
+    task :cucumber do
+      abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
     end
   end
-  desc 'Alias for cucumber:ok'
-  task :cucumber => 'cucumber:ok'
-
-  task :default => :cucumber
-
-  task :features => :cucumber do
-    STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
-  end
-
-  # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.
-  task 'test:prepare' do
-  end
-
-  task :stats => 'cucumber:statsetup'
-rescue LoadError
-  desc 'cucumber rake task not available (cucumber not installed)'
-  task :cucumber do
-    abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
-  end
-end
 
 end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,6 +1,6 @@
 namespace :brewformulas do
   namespace :sidekiq do
-    desc "Start all schedule jobs"
+    desc 'Start all schedule jobs'
     task start: :environment do
       HomebrewFormulaImportWorker.perform_async
     end

--- a/spec/models/homebrew/formula_conflict_spec.rb
+++ b/spec/models/homebrew/formula_conflict_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Homebrew::FormulaConflict do
-
   describe 'DB' do
     it do
       should have_db_column(:formula_id).of_type(:integer)
@@ -27,5 +26,4 @@ describe Homebrew::FormulaConflict do
       should validate_uniqueness_of(:conflict_id).scoped_to(:formula_id)
     end
   end
-
 end

--- a/spec/models/homebrew/formula_dependency_spec.rb
+++ b/spec/models/homebrew/formula_dependency_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Homebrew::FormulaDependency do
-
   describe 'DB' do
     it do
       should have_db_column(:formula_id).of_type(:integer)
@@ -27,5 +26,4 @@ describe Homebrew::FormulaDependency do
       should validate_uniqueness_of(:dependency_id).scoped_to(:formula_id)
     end
   end
-
 end

--- a/spec/models/homebrew/formula_spec.rb
+++ b/spec/models/homebrew/formula_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Homebrew::Formula do
-
   describe 'DB' do
     it do
       should have_db_column(:name).of_type(:string)
-                                  .with_options(null: false)
+        .with_options(null: false)
     end
     it { should have_db_column(:version).of_type(:string) }
     it { should have_db_column(:homepage).of_type(:string) }
@@ -13,17 +12,17 @@ describe Homebrew::Formula do
     it { should have_db_column(:touched_on).of_type(:date) }
     it do
       should have_db_column(:filename).of_type(:string)
-                                      .with_options(null: false)
+        .with_options(null: false)
     end
     it do
       should have_db_column(:description_automatic).of_type(:boolean)
-                                                   .with_options(default:
+        .with_options(default:
                                                                  false)
     end
     it do
       should have_db_column(:external).of_type(:boolean)
-                                      .with_options(default: false,
-                                                    null: false)
+        .with_options(default: false,
+                      null: false)
     end
     it { should have_db_index(:filename) }
     it { should have_db_index(:external) }
@@ -67,5 +66,4 @@ describe Homebrew::Formula do
     end
     it { should validate_presence_of(:name) }
   end
-
 end


### PR DESCRIPTION
Corrected most of Rubocop offenses automagically with `rubocop -a` and by hand.

There are still some line lengths offenses in comments and long string lines that I don't mark as needed to fix.

And there's the `app/workers/homebrew_formula_import_worker.rb` that offends ABC and MethodLength cops. Still I would avoid changing it.