### PR TITLE
Add en.hits

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
   descriptions: "Descriptions"
   distance_of_time_since_updated_ago: "%{dotiw} ago"
   filenames: "Filenames"
+  hits: "Hits"
   homepage: "homepage"
   names: "Names"
   next_page: "Next page"


### PR DESCRIPTION
Hovering the cursor over the Hits label currently yields "translation missing: en.hits"
I think this will fix that